### PR TITLE
added some code for order preserving encryption

### DIFF
--- a/my-app/src/main/java/jope/BigDecimalUtils.java
+++ b/my-app/src/main/java/jope/BigDecimalUtils.java
@@ -1,0 +1,264 @@
+package jope;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+/**
+ * Several useful BigDecimal mathematical functions.
+ */
+public class BigDecimalUtils {
+
+	/**
+	 * Compute x^exponent to a given scale. Uses the same algorithm as class
+	 * numbercruncher.mathutils.IntPower.
+	 *
+	 * @param x
+	 *            the value x
+	 * @param exponent
+	 *            the exponent value
+	 * @param scale
+	 *            the desired scale of the result
+	 * @return the result value
+	 */
+	public static BigDecimal intPower(BigDecimal x, long exponent, int scale) {
+
+		// If the exponent is negative, compute 1/(x^-exponent).
+		if (exponent < 0)
+			return BigDecimal.ONE.divide(intPower(x, -exponent, scale), scale,
+					BigDecimal.ROUND_HALF_EVEN);
+
+		BigDecimal power = BigDecimal.valueOf(1);
+
+		// Loop to compute value^exponent.
+		while (exponent > 0) {
+
+			// Is the rightmost bit a 1?
+			if ((exponent & 1) == 1)
+				power = power.multiply(x).setScale(scale, BigDecimal.ROUND_HALF_EVEN);
+
+			// Square x and shift exponent 1 bit to the right.
+			x = x.multiply(x).setScale(scale, BigDecimal.ROUND_HALF_EVEN);
+			exponent >>= 1;
+
+		}
+
+		return power;
+	}
+
+	/**
+	 * Compute the integral root of x to a given scale, x >= 0. Use Newton's algorithm.
+	 *
+	 * @param x
+	 *            the value of x
+	 * @param index
+	 *            the integral root value
+	 * @param scale
+	 *            the desired scale of the result
+	 * @return the result value
+	 */
+	public static BigDecimal intRoot(BigDecimal x, int index, int scale) {
+
+		// Check that x >= 0.
+		if (x.signum() < 0)
+			throw new IllegalArgumentException("x < 0");
+
+		int sp1 = scale + 1;
+		BigDecimal n = x;
+		BigDecimal i = BigDecimal.valueOf(index);
+		BigDecimal im1 = BigDecimal.valueOf(index - 1);
+		BigDecimal tolerance = BigDecimal.valueOf(5).movePointLeft(sp1);
+		BigDecimal xPrev;
+
+		// The initial approximation is x/index.
+		x = x.divide(i, scale, BigDecimal.ROUND_HALF_EVEN);
+
+		// Loop until the approximations converge
+		// (two successive approximations are equal after rounding).
+		do {
+			// x^(index-1)
+
+			BigDecimal xToIm1 = x.pow(index - 1);
+
+			// x^index
+			BigDecimal xToI = x.multiply(xToIm1).setScale(sp1, BigDecimal.ROUND_HALF_EVEN);
+
+			// n + (index-1)*(x^index)
+			BigDecimal numerator = n.add(im1.multiply(xToI)).setScale(sp1,
+					BigDecimal.ROUND_HALF_EVEN);
+
+			// (index*(x^(index-1))
+			BigDecimal denominator = i.multiply(xToIm1).setScale(sp1, BigDecimal.ROUND_HALF_EVEN);
+
+			// x = (n + (index-1)*(x^index)) / (index*(x^(index-1)))
+			xPrev = x;
+			x = numerator.divide(denominator, sp1, BigDecimal.ROUND_DOWN);
+
+		} while (x.subtract(xPrev).abs().compareTo(tolerance) > 0);
+
+		return x;
+	}
+
+	/**
+	 * Compute e^x to a given scale. Break x into its whole and fraction parts and compute (e^(1 +
+	 * fraction/whole))^whole using Taylor's formula.
+	 *
+	 * @param x
+	 *            the value of x
+	 * @param scale
+	 *            the desired scale of the result
+	 * @return the result value
+	 */
+	public static BigDecimal exp(BigDecimal x, int scale) {
+
+		// e^0 = 1
+		if (x.signum() == 0)
+			return BigDecimal.valueOf(1);
+
+		// If x is negative, return 1/(e^-x).
+		else if (x.signum() == -1)
+			return BigDecimal.ONE.divide(exp(x.negate(), scale), scale, BigDecimal.ROUND_HALF_EVEN);
+
+		// Compute the whole part of x.
+		BigDecimal xWhole = x.setScale(0, BigDecimal.ROUND_DOWN);
+
+		// If there isn't a whole part, compute and return e^x.
+		if (xWhole.signum() == 0)
+			return expTaylor(x, scale);
+
+		// Compute the fraction part of x.
+		BigDecimal xFraction = x.subtract(xWhole);
+
+		// z = 1 + fraction/whole
+		BigDecimal z = BigDecimal.ONE.add(xFraction.divide(xWhole, scale,
+				BigDecimal.ROUND_HALF_EVEN));
+
+		// t = e^z
+		BigDecimal t = expTaylor(z, scale);
+
+		BigDecimal maxLong = BigDecimal.valueOf(Long.MAX_VALUE);
+		BigDecimal result = BigDecimal.valueOf(1);
+
+		// Compute and return t^whole using intPower().
+		// If whole > Long.MAX_VALUE, then first compute products
+		// of e^Long.MAX_VALUE.
+		while (xWhole.compareTo(maxLong) >= 0) {
+			result = result.multiply(intPower(t, Long.MAX_VALUE, scale)).setScale(scale,
+					BigDecimal.ROUND_HALF_EVEN);
+
+			xWhole = xWhole.subtract(maxLong);
+		}
+
+		return result.multiply(intPower(t, xWhole.longValue(), scale)).setScale(scale,
+				BigDecimal.ROUND_HALF_EVEN);
+	}
+
+	/**
+	 * Compute e^x to a given scale by the Taylor series.
+	 *
+	 * @param x
+	 *            the value of x
+	 * @param scale
+	 *            the desired scale of the result
+	 * @return the result value
+	 */
+	private static BigDecimal expTaylor(BigDecimal x, int scale) {
+		BigDecimal factorial = BigDecimal.valueOf(1);
+		BigDecimal xPower = x;
+		BigDecimal sumPrev;
+
+		// 1 + x
+		BigDecimal sum = x.add(BigDecimal.valueOf(1));
+
+		// Loop until the sums converge
+		// (two successive sums are equal after rounding).
+		int i = 2;
+		do {
+			// x^i
+			xPower = xPower.multiply(x).setScale(scale, BigDecimal.ROUND_HALF_EVEN);
+
+			// i!
+			factorial = factorial.multiply(BigDecimal.valueOf(i));
+
+			// x^i/i!
+			BigDecimal term = xPower.divide(factorial, scale, BigDecimal.ROUND_HALF_EVEN);
+
+			// sum = sum + x^i/i!
+			sumPrev = sum;
+			sum = sum.add(term);
+
+			++i;
+		} while (sum.compareTo(sumPrev) != 0);
+
+		return sum;
+	}
+
+	/**
+	 * Compute the natural logarithm of x to a given scale, x > 0.
+	 */
+	public static BigDecimal ln(BigDecimal x, int scale) {
+
+		if (x.signum() <= 0)
+			throw new IllegalArgumentException("x <= 0");
+
+		// The number of digits to the left of the decimal point.
+		int magnitude = x.toString().length() - x.scale() - 1;
+
+		if (magnitude < 3)
+			return lnNewton(x, scale);
+		else {
+
+			// x^(1/magnitude)
+			BigDecimal root = intRoot(x, magnitude, scale);
+
+			// ln(x^(1/magnitude))
+			BigDecimal lnRoot = lnNewton(root, scale);
+
+			// magnitude*ln(x^(1/magnitude))
+			return BigDecimal.valueOf(magnitude).multiply(lnRoot)
+					.setScale(scale, BigDecimal.ROUND_HALF_EVEN);
+		}
+	}
+
+	public static BigDecimal log(BigDecimal x, BigDecimal base, int scale) {
+		return ln(x, scale).divide(ln(base, scale), 20, RoundingMode.HALF_EVEN);
+	}
+
+	/**
+	 * Compute the natural logarithm of x to a given scale, x > 0. Use Newton's algorithm.
+	 */
+	private static BigDecimal lnNewton(BigDecimal x, int scale) {
+		int sp1 = scale + 1;
+		BigDecimal n = x;
+		BigDecimal term;
+
+		// Convergence tolerance = 5*(10^-(scale+1))
+		BigDecimal tolerance = BigDecimal.valueOf(5).movePointLeft(sp1);
+
+		// Loop until the approximations converge
+		// (two successive approximations are within the tolerance).
+		do {
+
+			// e^x
+			BigDecimal eToX = exp(x, sp1);
+
+			// (e^x - n)/e^x
+			term = eToX.subtract(n).divide(eToX, sp1, BigDecimal.ROUND_DOWN);
+
+			// x - (e^x - n)/e^x
+			x = x.subtract(term);
+
+		} while (term.compareTo(tolerance) > 0);
+
+		return x.setScale(scale, BigDecimal.ROUND_HALF_EVEN);
+	}
+
+	public static void main(String[] args) {
+		BigDecimal x1 = new BigDecimal("1024");
+		BigDecimal x2 = new BigDecimal("2");
+
+		BigDecimal y = BigDecimalUtils.ln(x1, 20);
+		BigDecimal z = BigDecimalUtils.ln(x2, 20);
+
+		System.out.println(log(x1, x2, 20));
+	}
+}

--- a/my-app/src/main/java/jope/Coins.java
+++ b/my-app/src/main/java/jope/Coins.java
@@ -1,0 +1,137 @@
+package jope;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Return a bit string, generated from the given data string
+ *
+ * @author savvas
+ *
+ */
+public class Coins {
+
+	Cipher cipher = null;
+	SecretKeySpec k;
+	byte[] counterBA;
+	long counter;
+	ByteBuffer buffer;
+
+	public Coins(String key, BigInteger d) {
+
+		try {
+			// derive a key using the data to use in AES
+			Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
+			SecretKeySpec secret_key = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
+			sha256_HMAC.init(secret_key);
+			byte[] digest = sha256_HMAC.doFinal(d.toString().getBytes("UTF-8"));
+
+			this.cipher = Cipher.getInstance("AES/CTR/NoPadding"); // PKCS5Padding
+
+			// requires Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy
+			// Files
+			this.k = new SecretKeySpec(digest, "AES");
+
+			// FIXME: all 0 IV
+			this.buffer = ByteBuffer.allocate(Long.BYTES);
+			this.counterBA = new byte[16];
+			this.counter = 0;
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		// Encoder encoder = java.util.Base64.getEncoder();
+		// String enc = encoder.encodeToString(digest);
+
+	}
+
+	int byteIndex = 16;
+	int bitIndex = 8;
+	byte[] ctxt = null;
+	boolean[] coins = null;
+
+	public boolean next() {
+
+		// if we have consumed all bytes in the ciphertext, encrypt again and reset the byte index
+		if (this.byteIndex == 16) {
+
+			// encrypt again an all 0 array of 16 bytes. This should give a different ciphertext
+			// every time since we are using counter.
+			try {
+				this.buffer.putLong(this.counter);
+				byte[] b = this.buffer.array();
+				this.buffer.clear();
+				System.arraycopy(b, 0, this.counterBA, 8, 8);
+
+				IvParameterSpec iv = new IvParameterSpec(this.counterBA);
+				this.cipher.init(Cipher.ENCRYPT_MODE, this.k, iv);
+
+				this.ctxt = this.cipher.doFinal(new byte[16]);
+
+				this.counter++;
+			} catch (IllegalBlockSizeException e) {
+				e.printStackTrace();
+			} catch (BadPaddingException e) {
+				e.printStackTrace();
+			} catch (InvalidKeyException e) {
+				e.printStackTrace();
+			} catch (InvalidAlgorithmParameterException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+			// ciphertext should be 16 bytes long.
+			if (this.ctxt.length != 16)
+				throw new RuntimeException("invalid ctxt");
+
+			// reset the byte index so we start from the first byte again.
+			this.byteIndex = 0;
+		}
+
+		// if we have exhausted all bits in the byte indicated by byte index
+		if (this.bitIndex == 8) {
+
+			// convert current byte and move the index forward.
+			this.coins = byteToBoolArray(this.ctxt[this.byteIndex++]);
+			this.bitIndex = 0;
+		}
+
+		// return current bit and move bit index forward.
+		return this.coins[this.bitIndex++];
+	}
+
+	/**
+	 * Convert a byte to a boolean array
+	 *
+	 * @param b
+	 * @return
+	 */
+	public static boolean[] byteToBoolArray(byte b) {
+
+		boolean bs[] = new boolean[8];
+		bs[0] = ((b & 0x01) != 0);
+		bs[1] = ((b & 0x02) != 0);
+		bs[2] = ((b & 0x04) != 0);
+		bs[3] = ((b & 0x08) != 0);
+		bs[4] = ((b & 0x10) != 0);
+		bs[5] = ((b & 0x20) != 0);
+		bs[6] = ((b & 0x40) != 0);
+		bs[7] = ((b & 0x80) != 0);
+
+		return bs;
+	}
+
+	public static void main(String[] args) throws Exception {
+
+	}
+}

--- a/my-app/src/main/java/jope/Hgd.java
+++ b/my-app/src/main/java/jope/Hgd.java
@@ -1,0 +1,232 @@
+package jope;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+public class Hgd {
+
+	private final static double TWO_32 = Math.pow(2, 32) - 1;
+
+	private static final int bdPrecision = 20;
+	private static final BigDecimal SQRT_PRE = new BigDecimal(10).pow(bdPrecision);
+
+	// some repeated big integer/decimal literals
+	private final static BigDecimal decHalf = BigDecimal.valueOf(0.5);
+	private final static BigDecimal dec2 = BigDecimal.valueOf(2);
+	private final static BigDecimal dec3 = BigDecimal.valueOf(3);
+	private final static BigDecimal dec4 = BigDecimal.valueOf(4);
+	private final static BigDecimal dec7 = BigDecimal.valueOf(7);
+	private final static BigDecimal dec16 = BigDecimal.valueOf(16);
+	private final static BigDecimal dec2p = BigDecimal.valueOf(2 * Math.PI);
+	private final static BigDecimal log2p = decHalf
+			.multiply(BigDecimalUtils.ln(dec2p, bdPrecision));
+
+	/**
+	 * Private utility method used to compute the square root of a BigDecimal.
+	 */
+	private static BigDecimal sqrtNewtonRaphson(BigDecimal c, BigDecimal xn, BigDecimal precision) {
+		BigDecimal fx = xn.pow(2).add(c.negate());
+		BigDecimal fpx = xn.multiply(new BigDecimal(2));
+		BigDecimal xn1 = fx.divide(fpx, 2 * bdPrecision, RoundingMode.HALF_DOWN);
+		xn1 = xn.add(xn1.negate());
+		BigDecimal currentSquare = xn1.pow(2);
+		BigDecimal currentPrecision = currentSquare.subtract(c);
+		currentPrecision = currentPrecision.abs();
+
+		if (currentPrecision.compareTo(precision) <= -1)
+			return xn1;
+
+		return sqrtNewtonRaphson(c, xn1, precision);
+	}
+
+	/**
+	 * Uses Newton Raphson to compute the square root of a BigDecimal.
+	 */
+	private static BigDecimal bigSqrt(BigDecimal c) {
+		return sqrtNewtonRaphson(c, BigDecimal.ONE, BigDecimal.ONE.divide(SQRT_PRE));
+	}
+
+	/**
+	 *
+	 * @param coins
+	 * @return
+	 */
+	public static double prngDraw(Coins coins) {
+
+		long out = 0;
+		for (int i = 0; i < 32; i++)
+			// TODO don't calculate powers every time
+			out += coins.next() ? Math.pow(2, i) : 0;
+
+		return out / TWO_32;
+	}
+
+	public static BigInteger rhyper(BigInteger kk, BigInteger nn1, BigInteger nn2, Coins coins) {
+		if (kk.compareTo(BigInteger.TEN) > 0)
+			return hypergeometricHrua(coins, nn1, nn2, kk);
+		else
+			return hypergeometricHyp(coins, nn1, nn2, kk);
+	}
+
+	private static BigInteger hypergeometricHyp(Coins coins, BigInteger good, BigInteger bad,
+			BigInteger sample) {
+
+		BigDecimal d1 = new BigDecimal(bad.add(good).subtract(sample));
+		BigDecimal d2 = new BigDecimal(bad.min(good));
+
+		BigDecimal Y = d2;
+		BigDecimal K = new BigDecimal(sample);
+
+		while (Y.compareTo(BigDecimal.ZERO) > 0) {
+			BigDecimal U = BigDecimal.valueOf(prngDraw(coins));
+
+			BigDecimal d1K = d1.add(K);
+			BigDecimal inner = U.add(Y.divide(d1K, OPE.PRECISION, OPE.RM)).setScale(0,
+					RoundingMode.FLOOR);
+			Y = Y.subtract(inner);
+
+			K = K.subtract(BigDecimal.ONE);
+			if (K.compareTo(BigDecimal.ZERO) == 0)
+				break;
+		}
+
+		BigInteger Z = d2.subtract(Y).toBigInteger();
+		if (good.compareTo(bad) > 0)
+			Z = sample.subtract(Z);
+
+		return Z;
+	}
+
+	private final static BigDecimal D1 = new BigDecimal("1.7155277699214135");
+	private final static BigDecimal D2 = new BigDecimal("0.8989161620588988");
+
+	private static BigInteger hypergeometricHrua(Coins coins, BigInteger good, BigInteger bad,
+			BigInteger sampleBI) {
+
+		boolean moreGood;
+		BigDecimal badBD = new BigDecimal(bad);
+		BigDecimal goodBD = new BigDecimal(good);
+		BigDecimal mingoodbad;
+		BigDecimal maxgoodbad;
+		if (good.compareTo(bad) > 0) {
+			moreGood = true;
+			mingoodbad = badBD;
+			maxgoodbad = goodBD;
+
+		} else {
+			moreGood = false;
+			mingoodbad = goodBD;
+			maxgoodbad = badBD;
+		}
+
+		BigDecimal popsize = new BigDecimal(good.add(bad));
+		BigDecimal sample = new BigDecimal(sampleBI);
+		BigDecimal m = sample.min(popsize.subtract(sample));
+		BigDecimal d4 = mingoodbad.divide(popsize, OPE.PRECISION, OPE.RM);
+		BigDecimal d5 = BigDecimal.ONE.subtract(d4);
+		BigDecimal d6 = m.multiply(d4).add(decHalf);
+
+		BigDecimal d7a = popsize.subtract(m).multiply(sample).multiply(d4).multiply(d5)
+				.divide(popsize.subtract(BigDecimal.ONE), OPE.PRECISION, OPE.RM).add(decHalf);
+		BigDecimal d7 = bigSqrt(d7a);
+
+		BigDecimal d8 = D1.multiply(d7).add(D2);
+
+		BigDecimal mingoodbadplus1 = mingoodbad.add(BigDecimal.ONE);
+		BigDecimal d9 = m.add(BigDecimal.ONE).multiply(mingoodbadplus1)
+				.divide(popsize.add(dec2), OPE.PRECISION, OPE.RM);
+
+		BigDecimal d9plus1 = d9.add(BigDecimal.ONE);
+		BigDecimal d10 = loggam(d9plus1).add(loggam(mingoodbadplus1.subtract(d9)))
+				.add(loggam(m.subtract(d9).add(BigDecimal.ONE)))
+				.add(loggam(maxgoodbad.subtract(m).add(d9plus1)));
+
+		BigDecimal d11a = m.min(mingoodbad).add(BigDecimal.ONE);
+		BigDecimal d11b = d6.add(d7.multiply(dec16)).setScale(0, RoundingMode.FLOOR);
+		BigDecimal d11 = d11a.min(d11b);
+
+		BigDecimal Z;
+		while (true) {
+			BigDecimal X = BigDecimal.valueOf(prngDraw(coins));
+			BigDecimal Y = BigDecimal.valueOf(prngDraw(coins));
+			BigDecimal W = d6
+					.add(d8.multiply(Y.subtract(decHalf)).divide(X, OPE.PRECISION, OPE.RM));
+
+			if (W.compareTo(BigDecimal.ZERO) < 0 || W.compareTo(d11) >= 0)
+				continue;
+
+			Z = W.setScale(0, RoundingMode.FLOOR);
+
+			BigDecimal Zplus1 = Z.add(BigDecimal.ONE);
+			BigDecimal Zminus1 = Z.subtract(BigDecimal.ONE);
+			BigDecimal T = d10.subtract(loggam(Zplus1).add(loggam(mingoodbad.subtract(Zminus1)))
+					.add(loggam(m.subtract(Zminus1)))
+					.add(loggam(maxgoodbad.subtract(m).add(Zplus1))));
+
+			if (X.multiply(dec4.subtract(X)).subtract(dec3).compareTo(T) <= 0)
+				break;
+
+			if (X.multiply(X.subtract(T)).compareTo(BigDecimal.ONE) >= 0)
+				continue;
+
+			if (dec2.multiply(BigDecimalUtils.ln(X, bdPrecision)).compareTo(T) <= 0)
+				break;
+		}
+
+		if (moreGood)
+			Z = m.subtract(Z);
+
+		if (m.compareTo(sample) < 0)
+			Z = goodBD.subtract(Z);
+
+		return Z.toBigInteger();
+	}
+
+	private final static BigDecimal[] a = new BigDecimal[] {
+			BigDecimal.valueOf(8.333333333333333e-02), BigDecimal.valueOf(-2.777777777777778e-03),
+			BigDecimal.valueOf(7.936507936507937e-04), BigDecimal.valueOf(-5.952380952380952e-04),
+			BigDecimal.valueOf(8.417508417508418e-04), BigDecimal.valueOf(-1.917526917526918e-03),
+			BigDecimal.valueOf(6.410256410256410e-03), BigDecimal.valueOf(-2.955065359477124e-02),
+			BigDecimal.valueOf(1.796443723688307e-01), BigDecimal.valueOf(-1.39243221690590e+00) };
+
+	private static BigDecimal loggam(BigDecimal x) {
+
+		BigDecimal x0 = x;
+		int n = 0;
+
+		if (x.compareTo(BigDecimal.ONE) == 0 || x.compareTo(dec2) == 0)
+			return BigDecimal.ZERO;
+		else if (x.compareTo(dec7) <= 0) {
+			n = (int) (7.0 - x.doubleValue());
+			x0 = x.add(new BigDecimal(n));
+		}
+
+		BigDecimal x2 = BigDecimal.ONE.divide(x0.multiply(x0), OPE.PRECISION, OPE.RM);
+
+		BigDecimal gl0 = a[9];
+
+		for (int k = 8; k >= 0; k--) {
+			gl0 = gl0.multiply(x2);
+			gl0 = gl0.add(a[k]);
+		}
+
+		BigDecimal gl = gl0.divide(x0, OPE.PRECISION, OPE.RM).add(log2p)
+				.add(x0.subtract(decHalf).multiply(BigDecimalUtils.ln(x0, bdPrecision)))
+				.subtract(x0);
+
+		if (x.compareTo(dec7) <= 0)
+			for (int k = 1; k <= n + 1; k++) {
+				x0 = x0.subtract(BigDecimal.ONE);
+				gl = gl.subtract(BigDecimalUtils.ln(x0, bdPrecision));
+			}
+
+		return gl;
+	}
+
+	public static void main(String[] args) {
+
+		System.out.println(bigSqrt(new BigDecimal("213.57")));
+		System.out.println(Math.sqrt(213.57));
+	}
+}

--- a/my-app/src/main/java/jope/OPE.java
+++ b/my-app/src/main/java/jope/OPE.java
@@ -1,0 +1,203 @@
+package jope;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
+public class OPE {
+
+	final static int PRECISION = 10;
+	final static RoundingMode RM = RoundingMode.HALF_UP;
+
+	String key;
+	ValueRange inRange;
+	ValueRange outRange;
+
+	public OPE() {
+
+		this.key = "key";
+
+		this.inRange = new ValueRange(new BigInteger("2").pow(32).negate(),
+				new BigInteger("2").pow(32));
+		this.outRange = new ValueRange(new BigInteger("2").pow(48).negate(),
+				new BigInteger("2").pow(48));
+
+		// this.inRange = new ValueRange(BigInteger.ZERO, new BigInteger("100"));
+		// this.outRange = new ValueRange(BigInteger.ZERO, new BigInteger("200"));
+	}
+
+	private BigInteger encrypt(BigInteger ptxt) {
+
+		if (!this.inRange.contains(ptxt))
+			throw new RuntimeException("Plaintext is not within the input range");
+
+		return this.encryptRecursive(ptxt, this.inRange, this.outRange);
+	}
+
+	private BigInteger encryptRecursive(BigInteger ptxt, ValueRange inRange, ValueRange outRange) {
+
+		BigInteger inSize = inRange.size();
+		BigInteger outSize = outRange.size();
+
+		assert inSize.compareTo(outSize) <= 0;
+
+		if (inRange.size().compareTo(BigInteger.ONE) == 0) {
+			Coins coins = new Coins(this.key, ptxt);
+			return sampleUniform(outRange, coins);
+		}
+
+		BigInteger inEdge = inRange.start.subtract(BigInteger.ONE);
+		BigInteger outEdge = outRange.start.subtract(BigInteger.ONE);
+
+		BigDecimal two = new BigDecimal("2");
+		BigInteger m = new BigDecimal(outSize).divide(two, PRECISION, RoundingMode.CEILING)
+				.toBigInteger();
+		BigInteger mid = outEdge.add(m);
+
+		Coins coins = new Coins(this.key, mid);
+
+		BigInteger x = sampleHGD(inRange, outRange, mid, coins);
+
+		if (ptxt.compareTo(x) <= 0) {
+			inRange = new ValueRange(inEdge.add(BigInteger.ONE), x);
+			outRange = new ValueRange(outEdge.add(BigInteger.ONE), mid);
+		} else {
+			inRange = new ValueRange(x.add(BigInteger.ONE), inEdge.add(inSize));
+			outRange = new ValueRange(mid.add(BigInteger.ONE), outEdge.add(outSize));
+		}
+
+		return this.encryptRecursive(ptxt, inRange, outRange);
+	}
+
+	private BigInteger decrypt(BigInteger ctxt) {
+
+		if (!this.outRange.contains(ctxt))
+			throw new RuntimeException("Ciphertext is not within the input range");
+
+		return this.decryptRecursive(ctxt, this.inRange, this.outRange);
+	}
+
+	private BigInteger decryptRecursive(BigInteger ctxt, ValueRange inRange, ValueRange outRange) {
+
+		BigInteger inSize = inRange.size();
+		BigInteger outSize = outRange.size();
+
+		assert inSize.compareTo(outSize) <= 0;
+
+		if (inRange.size().compareTo(BigInteger.ONE) == 0) {
+			BigInteger inRangeMin = inRange.start;
+			Coins coins = new Coins(this.key, inRangeMin);
+			BigInteger sampledCtxt = sampleUniform(outRange, coins);
+
+			if (sampledCtxt.compareTo(ctxt) == 0)
+				return inRangeMin;
+			else
+				throw new RuntimeException("Invalid ciphertext");
+
+		}
+
+		BigInteger inEdge = inRange.start.subtract(BigInteger.ONE);
+		BigInteger outEdge = outRange.start.subtract(BigInteger.ONE);
+		BigDecimal two = new BigDecimal("2");
+		BigInteger m = new BigDecimal(outSize).divide(two, PRECISION, RoundingMode.CEILING)
+				.toBigInteger();
+		BigInteger mid = outEdge.add(m);
+
+		Coins coins = new Coins(this.key, mid);
+		BigInteger x = sampleHGD(inRange, outRange, mid, coins);
+
+		if (ctxt.compareTo(mid) <= 0) {
+			inRange = new ValueRange(inEdge.add(BigInteger.ONE), x);
+			outRange = new ValueRange(outEdge.add(BigInteger.ONE), mid);
+		} else {
+			inRange = new ValueRange(x.add(BigInteger.ONE), inEdge.add(inSize));
+			outRange = new ValueRange(mid.add(BigInteger.ONE), outEdge.add(outSize));
+		}
+
+		return this.decryptRecursive(ctxt, inRange, outRange);
+	}
+
+	/**
+	 * Uniformly select a number from the range using the bit list as a source of randomness
+	 *
+	 * @param outRange
+	 * @param coins
+	 * @return
+	 */
+	private static BigInteger sampleUniform(ValueRange inRange, Coins coins) {
+
+		ValueRange curRange = new ValueRange(inRange);
+
+		assert curRange.size().compareTo(BigInteger.ZERO) != 0;
+
+		while (curRange.size().compareTo(BigInteger.ONE) > 0) {
+
+			// System.out.println(curRange.start + " " + curRange.end);
+
+			BigInteger mid = curRange.start.add(curRange.end).divide(new BigInteger("2"));
+
+			boolean bit = coins.next();
+			if (bit == false)
+				curRange.end = mid;
+			else if (bit == true)
+				curRange.start = mid.add(BigInteger.ONE);
+			else
+				throw new RuntimeException("Unexpected bit value");
+		}
+
+		assert curRange.size().compareTo(BigInteger.ZERO) != 0;
+
+		return curRange.start;
+	}
+
+	private static BigInteger sampleHGD(ValueRange inRange, ValueRange outRange,
+			BigInteger nSample, Coins coins) {
+
+		BigInteger inSize = inRange.size();
+		BigInteger outSize = outRange.size();
+
+		assert inSize.compareTo(BigInteger.ZERO) > 0 && outSize.compareTo(BigInteger.ZERO) > 0;
+		assert inSize.compareTo(outSize) <= 0;
+		assert outRange.contains(nSample);
+
+		BigInteger nSampleIndex = nSample.subtract(outRange.start).add(BigInteger.ONE);
+
+		if (inSize.compareTo(outSize) == 0)
+			return inRange.start.add(nSampleIndex).subtract(BigInteger.ONE);
+
+		BigInteger inSampleNum = Hgd.rhyper(nSampleIndex, inSize, outSize, coins);
+
+		if (inSampleNum.compareTo(BigInteger.ZERO) == 0)
+			return inRange.start;
+		else if (inSampleNum.compareTo(inSize) == 0)
+			return inRange.end;
+		else {
+			BigInteger inSample = inRange.start.add(inSampleNum);
+
+			assert inRange.contains(inSample);
+
+			return inSample;
+		}
+	}
+
+	public static void main(String[] args) {
+		OPE o = new OPE();
+
+		for (int i = -99999; i <= 99999; i++) {
+
+			BigInteger p = new BigInteger("" + i);
+
+			BigInteger e = o.encrypt(p);
+			BigInteger d = o.decrypt(e);
+
+			if (d.compareTo(p) != 0)
+				throw new RuntimeException("failed: " + p + " " + d);
+
+			if (i % 10 == 0)
+				System.out.println(e + " " + d);
+		}
+
+		System.out.println("done");
+
+	}
+}

--- a/my-app/src/main/java/jope/ValueRange.java
+++ b/my-app/src/main/java/jope/ValueRange.java
@@ -1,0 +1,55 @@
+package jope;
+
+import java.math.BigInteger;
+
+/**
+ *
+ * @author Savvas Savvides <savvas@purdue.edu>
+ *
+ */
+public class ValueRange {
+
+	BigInteger start;
+	BigInteger end;
+
+	public ValueRange(BigInteger s, BigInteger e) {
+		this.start = s;
+		this.end = e;
+
+		if (this.start.compareTo(this.end) > 0)
+			throw new RuntimeException("start > end");
+
+	}
+
+	/**
+	 * Copy constructor
+	 *
+	 * @param other
+	 */
+	public ValueRange(ValueRange other) {
+		this(other.start, other.end);
+	}
+
+	/**
+	 * the range length, including its start and end
+	 *
+	 * @return
+	 */
+	public BigInteger size() {
+		return this.end.subtract(this.start).add(BigInteger.ONE);
+	}
+
+	/**
+	 * Return a number of bits required to encode any value within the range
+	 *
+	 * @return
+	 */
+	public long rangeBitSize() {
+		return (long) Math.ceil(Math.log(this.size().longValueExact()) / Math.log(2));
+	}
+
+	public boolean contains(BigInteger number) {
+		return number.compareTo(this.start) >= 0 && number.compareTo(this.end) <= 0;
+	}
+
+}

--- a/my-app/src/test/java/gr/uoa/di/ae/thesis/AEMongoCollectionTest.java
+++ b/my-app/src/test/java/gr/uoa/di/ae/thesis/AEMongoCollectionTest.java
@@ -186,4 +186,24 @@ public class AEMongoCollectionTest {
 		assertEquals("mike@bulls.com", res.first().get("e-mail"));
 	}
 	
+	@Test
+	public void shouldFindGreaterThanWithoutEncryption() {
+		Document document = new Document("name", new Document("first", "Michael").append("last", "Jordan")).append("year_of_birth", 1962);
+		collection.insertOne(document);
+		FindIterable<Document> res = collection.find(new Document("year_of_birth", new Document("$gt", 1960)));
+		System.out.println("1o document "+res.first());
+		assertEquals("Jordan", ((Document) res.first().get("name")).get("last"));
+	}
+	
+	@Test
+	public void shouldFindGreaterThanWithEncryption() {
+		aeMongoCollection.setEncryptedField("year_of_birth", EncryptionType.ORDER_PRESERVING);
+		aeMongoCollection.importEncryptedFields();
+		Document document = new Document("name", new Document("first", "Michael").append("last", "Jordan")).append("year_of_birth", 1962);
+		collection.insertOne(document);
+		FindIterable<Document> res = collection.find(new Document("year_of_birth", new Document("$gt", 1960)));
+		System.out.println("1o document "+res.first());
+		assertEquals("Jordan", ((Document) res.first().get("name")).get("last"));
+	}
+	
 }


### PR DESCRIPTION
Μόλις πρόσθεσα κώδικα για order preserving encrpytion και δύο μικρά tests, ένα εκ των οποίων δουλεύει ήδη. Αν δείτε στο OPE.java έχει ένα παράδειγμα στη main με ένα loop που κρυπτογραφεί κι αποκρυπτογραφεί ακεραίους. Αργό είναι αλλά μας ενδιαφέρει η λειτουργικότητα περισσότερο.

Επίσης, απαιτεί το Java Cryptography Extension (JCE). Εγώ το εγκατέστησα ως εξής:
https://askubuntu.com/questions/780306/how-can-i-install-jce

Μόνο που έχω την oracle Java 8 ήδη οπότε χρειάστηκε να τρέξω μόνο το:

> sudo apt-get install oracle-java8-unlimited-jce-policy

Αν έχετε άλλη Java πιθανώς να θέλει άλλο τρόπο εγκατάστασης.

Αν το χρησιμοποιήσετε, να αναφερθείτε στο κείμενο στο εξής:
https://github.com/ssavvides/jope

Πάντως προέχει σίγουρα το κείμενο...
